### PR TITLE
Remove React from description of JSX semantics

### DIFF
--- a/13-element-refactor.html
+++ b/13-element-refactor.html
@@ -11,7 +11,7 @@
 
 <script type="text/babel">
 // Refactoring an element is a bit more tricky
-// First, React decides if a tag is an element by checking its case
+// First, casing of JSX determines whether a tag is an element or component
 // lower case means element
 // upper case means component
 


### PR DESCRIPTION
From my reading of sections 0-3, it seems like conflating React and JSX in this way was probably not intentional (as demystifying JSX seems like a goal to some degree). This PR updates the language of this section to be more accurate.